### PR TITLE
rename existing mpi to horovod

### DIFF
--- a/cmd/arena/commands/get.go
+++ b/cmd/arena/commands/get.go
@@ -114,7 +114,7 @@ func printSingleJobHelper(job TrainingJob, outFmt string) {
 
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", job.Name(),
 			strings.ToUpper(string(pod.Status.Phase)),
-			job.Trainer(),
+			strings.ToUpper(job.Trainer()),
 			job.Age(),
 			pod.Name,
 			hostIP)

--- a/cmd/arena/commands/submit.go
+++ b/cmd/arena/commands/submit.go
@@ -133,9 +133,9 @@ var (
 	submitLong = `Submit a training job.
 
 Available Commands:
-  tfjob,tf          Submit a TFJob.
-  mpijob,mpi        Submit a MPIJob.
-  standalonejob,sj  Submit a standalone Job.
+  tfjob,tf             Submit a TFJob.
+  horovod,hj           Submit a Horovod Job.
+  standalonejob,sj     Submit a standalone Job.
     `
 )
 

--- a/cmd/arena/commands/submit_horovod.go
+++ b/cmd/arena/commands/submit_horovod.go
@@ -14,13 +14,11 @@ func NewSubmitHorovodJobCommand() *cobra.Command {
 	var (
 		submitArgs submitHorovodJobArgs
 	)
-	// TODO(cheyang): set this mode as mpijob for short time
-	submitArgs.Mode = "mpijob"
 
 	var command = &cobra.Command{
-		Use:     "mpijob",
-		Short:   "Submit MPIJob as training job.",
-		Aliases: []string{"mpi"},
+		Use:     "horovodjob",
+		Short:   "Submit horovodjob as training job.",
+		Aliases: []string{"hj"},
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				cmd.HelpFunc()(cmd, args)

--- a/cmd/arena/commands/trainer.go
+++ b/cmd/arena/commands/trainer.go
@@ -11,7 +11,7 @@ func NewTrainers(client *kubernetes.Clientset) []Trainer {
 
 	trainers := []Trainer{}
 	trainerInits := []func(client *kubernetes.Clientset) Trainer{
-		NewMPIJobTrainer,
+		NewHorovodJobTrainer,
 		NewStandaloneJobTrainer,
 		NewTensorFlowJobTrainer}
 


### PR DESCRIPTION
In order to support MPI operator, we have to rename the current MPI implementation to Horovod.